### PR TITLE
Update Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,7 @@
 FROM ruby:2.3.3
 ENV http_proxy="http://proxy-us.intel.com:911"
 ENV https_proxy="http://proxy-us.intel.com:912"
+ENV no_proxy="intel.com,.intel.com,localhost,127.0.0.1"
 RUN apt-get update -qq && apt-get install -y build-essential libpq-dev nodejs
 RUN mkdir /myapp
 WORKDIR /myapp


### PR DESCRIPTION
bypass proxy for internal and local hosts, otherwise internally-hosted gems are not accessible